### PR TITLE
Fix “Coding Standards” GitHub Action

### DIFF
--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Validate composer.json
         run: composer validate
 
-      - name: Install dependencies
-        run: composer require friendsofphp/php-cs-fixer --dev --no-scripts --no-interaction --update-with-dependencies
+      - name: Install PHP CS Fixer
+        run: composer remove ezsystems/ezplatform-admin-ui --no-interaction && composer require friendsofphp/php-cs-fixer --dev --no-interaction
 
       - name: Validate coding standards in source
         run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony src/

--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -18,7 +18,7 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        run: composer require friendsofphp/php-cs-fixer --no-scripts --no-interaction
+        run: composer require friendsofphp/php-cs-fixer --no-scripts --no-interaction --no-update --dev
 
       - name: Validate coding standards in source
         run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony src/

--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -18,7 +18,7 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer require friendsofphp/php-cs-fixer --no-scripts --no-interaction
 
       - name: Validate coding standards in source
         run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony src/

--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -17,8 +17,11 @@ jobs:
       - name: Validate composer.json
         run: composer validate
 
+      - name: Remove eZ Platform Admin UI's dependency
+        run: composer remove ezsystems/ezplatform-admin-ui --no-interaction
+
       - name: Install PHP CS Fixer
-        run: composer remove ezsystems/ezplatform-admin-ui --no-interaction && composer require friendsofphp/php-cs-fixer --dev --no-interaction
+        run: composer require friendsofphp/php-cs-fixer --dev --no-interaction
 
       - name: Validate coding standards in source
         run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony src/

--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -18,7 +18,7 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        run: composer require friendsofphp/php-cs-fixer --no-scripts --no-interaction --no-update --dev
+        run: composer require friendsofphp/php-cs-fixer --dev --no-scripts --no-interaction --update-with-dependencies
 
       - name: Validate coding standards in source
         run: vendor/bin/php-cs-fixer fix --dry-run --rules=@Symfony src/

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,5 @@
   },
   "require": {
     "ezsystems/ezplatform-admin-ui": "~2.0.0"
-  },
-  "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.16"
   }
 }


### PR DESCRIPTION
* It was working in [check run 730198332](https://github.com/adriendupuis/ezplatform-admin/pull/1/checks?check_run_id=730198332)
* It doesn't anymore: [check run 731511589](https://github.com/adriendupuis/ezplatform-admin/pull/2/checks?check_run_id=731511589)

As ezsystems/ezplatform-admin-ui's dependencies couldn't be satisfied anymore, as I didn't like to require php-cs-fixer in users' projects, the action now remove the first and install the second.