### PR TITLE
Open a tab from URL hash (anchor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ imports:
 ```
 
 
+Features
+--------
+
+* Content
+  - Content Type Usage: Content count per content type.
+* Navigation
+  - Tab Opener: Open a tab according to URL hash. Example: Right-click on a non-first tab and open it in a new window, the tab is opened.
+
+
 TODO
 ----
 

--- a/src/bundle/Resources/encore/ez.config.manager.js
+++ b/src/bundle/Resources/encore/ez.config.manager.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = (eZConfig, eZConfigManager) => {
+    eZConfigManager.add({
+        eZConfig,
+        entryName: 'ezplatform-admin-ui-layout-js',
+        newItems: [path.resolve(__dirname, '../public/js/tab_opener.js')],
+    });
+};

--- a/src/bundle/Resources/public/js/tab_opener.js
+++ b/src/bundle/Resources/public/js/tab_opener.js
@@ -1,0 +1,5 @@
+$(function () {
+    if (document.location.hash.startsWith('#ez-tab')) {
+        $('[href="' + document.location.hash + '"]').click();
+    }
+});

--- a/src/bundle/Resources/public/js/tab_opener.js
+++ b/src/bundle/Resources/public/js/tab_opener.js
@@ -1,5 +1,10 @@
 $(function () {
-    if (document.location.hash.startsWith('#ez-tab')) {
-        $('[href="' + document.location.hash + '"]').click();
+    let tab = $('[href="' + document.location.hash + '"]');
+    if (tab.length) {
+        if (document.location.hash.startsWith('#ez-tab')) {
+            tab.click();
+        } else if ('tab' === tab.attr('role') && tab.parents('.ez-main-nav').length) {
+            document.location = $(document.location.hash).find('.nav-link').attr('href');
+        }
     }
 });


### PR DESCRIPTION
Allow to right-click-open a tab in a new window.

**Examples**:
* Main navigation bar's tabs are redirected to their first sub-tab:
  - `systeminfo#main__content` will be redirected to `view/content/<content_id>/full/1/2`
  - `systeminfo#ezplatform_page_manager` will be redirected to `site/list`
  - `site/list#main_admin` will be redirected to `systeminfo`
* Other tabs are opened when arriving on the page:
  - `systeminfo#ez-tab-systeminfo-php`
  - `view/content/<content_id>/full/1/<location_id>#ez-tab-location-view-versions`
  - etc.